### PR TITLE
Use streaming reader for fastchess windows compatibility

### DIFF
--- a/src/lib.zig
+++ b/src/lib.zig
@@ -87,7 +87,7 @@ const IoContext = struct {
     out: *std.Io.Writer,
 
     fn init() IoContext {
-        stdin = std.fs.File.stdin().reader(&in_buffer);
+        stdin = std.fs.File.stdin().readerStreaming(&in_buffer);
         stdout = std.fs.File.stdout().writer(&out_buffer);
         return .{
             .in = &stdin.interface,

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -88,7 +88,7 @@ const IoContext = struct {
 
     fn init() IoContext {
         stdin = std.fs.File.stdin().readerStreaming(&in_buffer);
-        stdout = std.fs.File.stdout().writer(&out_buffer);
+        stdout = std.fs.File.stdout().writerStreaming(&out_buffer);
         return .{
             .in = &stdin.interface,
             .out = &stdout.interface,


### PR DESCRIPTION
I recently made the same change in pawnocchio which fixes a crash when running under fastchess on windows. I think the issue is fastchess using anonymous pipes and something not quite lining up in the stdlib, not sure.